### PR TITLE
Python 2 Unicode issues

### DIFF
--- a/main.py
+++ b/main.py
@@ -75,7 +75,7 @@ class JobManager(object):
                 temp = ScrapeJob(job_letter)
                 temp["subject_start"] = job["subject_start"] + s
                 temp["subject_step"] = threads_per_letter
-                logging.info("Made job: {0}".format(temp))
+                logging.info(u"Made job: {0}".format(temp))
                 self.jobs.put_nowait(temp)
     
     def run_jobs(self, queue):

--- a/navigation.py
+++ b/navigation.py
@@ -121,8 +121,8 @@ class SolusSession(object):
 
     def select_alphanum(self, alphanum):
         """Navigates to a letter/number"""
-        logging.debug("Selecting letter {0}".format(alphanum))
-        self._catalog_post('DERIVED_SSS_BCC_SSR_ALPHANUM_{0}'.format(alphanum.upper()))
+        logging.debug(u"Selecting letter {0}".format(alphanum))
+        self._catalog_post(u'DERIVED_SSS_BCC_SSR_ALPHANUM_{0}'.format(alphanum.upper()))
 
         if self.recovery_state < 0:
             self.recovery_stack[0] = alphanum
@@ -131,11 +131,11 @@ class SolusSession(object):
 
     def dropdown_subject(self, subject_unique):
         """Opens the dropdown menu for a subject"""
-        logging.debug("Dropping down subject with unique '{0}'".format(subject_unique))
+        logging.debug(u"Dropping down subject with unique '{0}'".format(subject_unique))
 
         action = self.parser.subject_action(subject_unique)
         if not action:
-            raise Exception("Tried to drop down an invalid subject unique '{0}'".format(subject_unique))
+            raise Exception(u"Tried to drop down an invalid subject unique '{0}'".format(subject_unique))
 
         self._catalog_post(action)
 
@@ -144,11 +144,11 @@ class SolusSession(object):
 
     def rollup_subject(self, subject_unique):
         """Closes the dropdown menu for a subject"""
-        logging.debug("Rolling up subject with a unique '{0}'".format(subject_unique))
+        logging.debug(u"Rolling up subject with a unique '{0}'".format(subject_unique))
 
         action = self.parser.subject_action(subject_unique)
         if not action:
-            raise Exception("Tried to roll up an invalid subject unique '{0}'".format(subject_unique))
+            raise Exception(u"Tried to roll up an invalid subject unique '{0}'".format(subject_unique))
 
         self._catalog_post(action)
 
@@ -159,11 +159,11 @@ class SolusSession(object):
 
     def open_course(self, course_unique):
         """Opens a course page"""
-        logging.debug("Opening course with unique '{0}'".format(course_unique))
+        logging.debug(u"Opening course with unique '{0}'".format(course_unique))
 
         action = self.parser.course_action(course_unique)
         if not action:
-            raise Exception("Tried to open a course with an invalid unique '{0}'".format(course_unique))
+            raise Exception(u"Tried to open a course with an invalid unique '{0}'".format(course_unique))
 
         self._catalog_post(action)
 
@@ -190,7 +190,7 @@ class SolusSession(object):
 
     def switch_to_term(self, term_unique):
         """Shows the sections for the term"""
-        logging.debug("Switching to term with unique '{0}'".format(term_unique))
+        logging.debug(u"Switching to term with unique '{0}'".format(term_unique))
         value = self.parser.term_value(term_unique)
 
         self._catalog_post(action='DERIVED_SAA_CRS_SSR_PB_GO$98$', extras={'DERIVED_SAA_CRS_TERM_ALT': value})
@@ -211,11 +211,11 @@ class SolusSession(object):
         Opens the dedicated page for the provided section unique.
         Used for deep scrapes
         """
-        logging.debug("Visiting section page for section with unique '{0}'".format(section_unique))
+        logging.debug(u"Visiting section page for section with unique '{0}'".format(section_unique))
 
         action = self.parser.section_action(section_unique)
         if not action:
-            raise Exception("Tried to open a section with an invalid unique '{0}'".format(section_unique))
+            raise Exception(u"Tried to open a section with an invalid unique '{0}'".format(section_unique))
 
         self._catalog_post(action)
 

--- a/parser.py
+++ b/parser.py
@@ -28,7 +28,7 @@ class SolusParser(object):
         try:
             bs4.BeautifulSoup("", self._souplib)
         except bs4.FeatureNotFound as e:
-            logging.warning("Not using {0} for parsing, using builtin parser instead".format(self._souplib))
+            logging.warning(u"Not using {0} for parsing, using builtin parser instead".format(self._souplib))
             self._souplib = "html.parser"
 
     def update_html(self, text):
@@ -76,7 +76,7 @@ class SolusParser(object):
         """Return the action for the subject unique"""
         tag = self.soup.find("a", id=self.ALL_SUBJECTS, text=subject_unique)
         if not tag:
-            logging.warning("Couldn't find the subject '{0}'".format(subject_unique))
+            logging.warning(u"Couldn't find the subject '{0}'".format(subject_unique))
             return None
 
         return tag["id"]
@@ -85,7 +85,7 @@ class SolusParser(object):
         """Return the action for the course unique"""
         tag = self.soup.find("a", id=self.ALL_COURSES, text=course_unique)
         if not tag:
-            logging.warning("Couldn't find the course '{0}'".format(course_unique))
+            logging.warning(u"Couldn't find the course '{0}'".format(course_unique))
             return None
 
         return tag["id"]
@@ -98,7 +98,7 @@ class SolusParser(object):
 
         tag = dropdown.find("option", text=term_unique)
         if not tag:
-            logging.warning("Couldn't find the term '{0}'")
+            logging.warning(u"Couldn't find the term '{0}'".format(term_unique))
             return None
 
         return tag["value"]
@@ -107,7 +107,7 @@ class SolusParser(object):
         """Return the action of the section unique"""
         tag = self.soup.find("a", id=self.ALL_SECTIONS, text=section_unique)
         if not tag:
-            logging.warning("Couldn't find section '{0}'".format(section_unique))
+            logging.warning(u"Couldn't find section '{0}'".format(section_unique))
             return None
 
         return tag["id"]
@@ -350,7 +350,7 @@ class SolusParser(object):
 
         m = self.COURSE_INFO.search(temp)
         if not m:
-            raise Exception("Title found ({0}) didn't match regular expression".format(temp))
+            raise Exception(u"Title found ({0}) didn't match regular expression".format(temp))
 
         ret['basic'] = {
             'title' : m.group(3),
@@ -433,7 +433,7 @@ class SolusParser(object):
                         ret['extra']['CEAB'][labels[x].string[:-1]] = temp
 
             else:
-                raise Exception('Encountered unexpected info_box with title: "{0}"'.format(box_title))
+                raise Exception(u"Encountered unexpected info_box with title: '{0}'".format(box_title))
 
         return ret
 
@@ -497,7 +497,7 @@ class SolusParser(object):
                 for i in range(0, len(lis), 2):
                     last_name = lis[i].strip()
                     other_names = lis[i+1].strip()
-                    instructors.append("{0}, {1}".format(last_name, other_names))
+                    instructors.append(u"{0}, {1}".format(last_name, other_names))
 
             # Location
             location = values[x+3]

--- a/scraper.py
+++ b/scraper.py
@@ -12,7 +12,7 @@ class SolusScraper(object):
     def start(self):
         """Starts running the scrape outlined in the job"""
 
-        logging.info("Starting job: {0}".format(self.job))
+        logging.info(u"Starting job: {0}".format(self.job))
 
         try:
             self.scrape_letters()
@@ -44,7 +44,7 @@ class SolusScraper(object):
         # Iterate over all subjects
         for subject in all_subjects:
 
-            logging.info("--Subject: {abbreviation} - {title}".format(**subject))
+            logging.info(u"--Subject: {abbreviation} - {title}".format(**subject))
 
             self.session.dropdown_subject(subject["_unique"])
 
@@ -68,8 +68,8 @@ class SolusScraper(object):
 
             course_attrs = self.session.parser.course_attrs()
 
-            logging.info("----Course: {number} - {title}".format(**course_attrs['basic']))
-            logging.debug("COURSE DATA DUMP: {0}".format(course_attrs['extra']))
+            logging.info(u"----Course: {number} - {title}".format(**course_attrs['basic']))
+            logging.debug(u"COURSE DATA DUMP: {0}".format(course_attrs['extra']))
 
             self.session.show_sections()
 
@@ -83,7 +83,7 @@ class SolusScraper(object):
         # Get all terms on the page and iterate over them
         all_terms = self.session.parser.all_terms()
         for term in all_terms:
-            logging.info("------Term: {year} - {season}".format(**term))
+            logging.info(u"------Term: {year} - {season}".format(**term))
             self.session.switch_to_term(term["_unique"])
 
             self.session.view_all_sections()
@@ -97,9 +97,9 @@ class SolusScraper(object):
 
         if logging.getLogger().isEnabledFor(logging.INFO):
             for section in all_sections:
-                logging.info("--------Section: {class_num}-{type} ({solus_id}) -- {status}".format(**section["basic"]))
+                logging.info(u"--------Section: {class_num}-{type} ({solus_id}) -- {status}".format(**section["basic"]))
                 if not self.job["deep"]:
-                    logging.debug("SECTION CLASS DATA: {0}".format(section["classes"]))
+                    logging.debug(u"SECTION CLASS DATA: {0}".format(section["classes"]))
 
         # Deep scrape, go to the section page and add the data there
         if self.job["deep"]:
@@ -112,4 +112,4 @@ class SolusScraper(object):
 
                 self.session.return_from_section()
 
-                logging.debug("SECTION DEEP DATA DUMP: {0}".format(all_sections[i]))
+                logging.debug(u"SECTION DEEP DATA DUMP: {0}".format(all_sections[i]))


### PR DESCRIPTION
Some characters in the scraped data cause the scraper to break when using Python 2 (v2.7.3 specifically).

The error is a `UnicodeEncodeError` and can be reliably reproduced by attempting to format a string with the course name of BIOL 951.

Scrape job to reproduce:
`ScrapeJob(letters="B", deep=False, subject_start=1, subject_end=2, course_start=137)`

Details:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "./main.py", line 105, in run_jobs
    SolusScraper(session, job).start()
  File "./scraper.py", line 18, in start
    self.scrape_letters()
  File "./scraper.py", line 31, in scrape_letters
    self.scrape_subjects()
  File "./scraper.py", line 51, in scrape_subjects
    self.scrape_courses()
  File "./scraper.py", line 71, in scrape_courses
    logging.info("----Course: {number} - {title}".format(**course_attrs['basic']))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xa0' in position 7: ordinal not in range(128)
```
