### PR TITLE
Use Daemon threads

### DIFF
--- a/main.py
+++ b/main.py
@@ -83,13 +83,11 @@ class JobManager(object):
 
         # Run all the jobs in the job queue
         while True:
-            try:
-                job = self.jobs.get_nowait()
-            except Empty as e:
-                return
+            job = self.jobs.get()
 
             # Run the job
             SolusScraper(session, job).start()
+            self.jobs.task_done()
 
     def start_jobs(self):
         """Start the threads that perform the jobs"""
@@ -97,10 +95,10 @@ class JobManager(object):
         threads = []
         for x in range(self.config["threads"]):
             threads.append(Thread(target=self.run_jobs))
+            threads[-1].daemon = True
             threads[-1].start()
 
-        for t in threads:
-            t.join()
+        self.jobs.join()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the current master branch, the scraper uses standard non-daemon threads and then uses .join() on each one to prevent the program from ending.

I think it would be better to use daemon threads (daemon threads die when the parent thread dies) and then use .join() on the queue.  We then never have to worry about the threads ending (they can be in an infinite loop reading from the queue), and yet they will still be cleaned up when the scraper exits.
