### PR TITLE
FIxed scraper for 2016 SOLUS changes

### DIFF
--- a/main.py
+++ b/main.py
@@ -117,7 +117,7 @@ def _init_logging():
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(logging.Formatter("[%(asctime)s][%(levelname)s][%(processName)s]: %(message)s"))
     root_logger.addHandler(handler)
-    root_logger.setLevel(logging.INFO)
+    root_logger.setLevel(logging.DEBUG)
 
     logging.getLogger("requests").setLevel(logging.WARNING)
 
@@ -136,8 +136,9 @@ if __name__ == "__main__":
     config = dict(
         name = "Shallow scrape with threading",
         description = "Scrapes the entire catalog using multiple threads",
-        threads = 4,
+        threads = 1,
         job = ScrapeJob(letters="ABCDEFGHIJKLMNOPQRSTUVWXYZ", deep=False),
+        threads_per_letter = 4,
     )
 
     # Start scraping

--- a/main.py
+++ b/main.py
@@ -117,7 +117,7 @@ def _init_logging():
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(logging.Formatter("[%(asctime)s][%(levelname)s][%(processName)s]: %(message)s"))
     root_logger.addHandler(handler)
-    root_logger.setLevel(logging.DEBUG)
+    root_logger.setLevel(logging.INFO)
 
     logging.getLogger("requests").setLevel(logging.WARNING)
 

--- a/main.py
+++ b/main.py
@@ -138,7 +138,7 @@ if __name__ == "__main__":
         description = "Scrapes the entire catalog using multiple threads",
         threads = 1,
         job = ScrapeJob(letters="ABCDEFGHIJKLMNOPQRSTUVWXYZ", deep=False),
-        threads_per_letter = 4,
+        threads_per_letter = 1,
     )
 
     # Start scraping

--- a/navigation.py
+++ b/navigation.py
@@ -165,42 +165,31 @@ class SolusSession(object):
 
     # ----------------------------- Courses ------------------------------------- #
 
-    def open_course(self, course_unique, action=None):
+    def open_course(self, course_unique):
         """Opens a course page"""
-        logging.debug(u"Opening course with unique '{0}', action: {1}".format(course_unique,action))
+        logging.debug(u"Opening course with unique '{0}'".format(course_unique))
         
-        actions = None
+        action = self.parser.course_action(course_unique)
+        if not action:
+            raise Exception(u"Tried to open a course with an invalid unique '{0}'".format(course_unique))
         
-        if action == None:
-            actions = self.parser.course_action(course_unique)
-            if len(actions)==0:
-                raise Exception(u"Tried to open a course with an invalid unique '{0}'".format(course_unique))
-            action = actions[0] 
-
         self._catalog_post(action)
-
-        # this is no longer guaranteed to work
+        
+        secondaryAction = self.parser.disambiguation_action()
+        
+        if secondaryAction:
+            logging.error(u"POSTING: {0}".format(secondaryAction))
+            self._catalog_post(secondaryAction)
+        
+        # unsure if this still works
         if self.recovery_state < 0:
             self.recovery_stack[2] = course_unique
-
-        if actions != None and len(actions)>1:
-            return actions[1:]
-        else:
-            return [actions]
-
-    # def return_to_offerings(self):
-    #     """Navigates back from course to subject"""
-    #     logging.debug("Returning from a course to disambiguation page")
-    #     self._catalog_post('DERIVED_SAA_CRS_RETURN_PB')
-
-    #     self.recovery_stack[3] = None
-    #     self.recovery_stack[2] = None
 
 
     def return_from_course(self):
         """Navigates back from course to subject"""
         logging.debug("Returning from a course")
-        #hacky, try to return from the new page first 
+        #hacky, attempt to return from the new page first 
         self._catalog_post('DERIVED_SAA_CRS_RETURN_PB')
         self._catalog_post('DERIVED_SSS_SEL_RETURN_PB')
 

--- a/navigation.py
+++ b/navigation.py
@@ -168,28 +168,28 @@ class SolusSession(object):
     def open_course(self, course_unique):
         """Opens a course page"""
         logging.debug(u"Opening course with unique '{0}'".format(course_unique))
-        
+
         action = self.parser.course_action(course_unique)
         if not action:
             raise Exception(u"Tried to open a course with an invalid unique '{0}'".format(course_unique))
         
         self._catalog_post(action)
         
+        #attempt to go one level deeper to deal with courses which have multiple 'careers'
         secondaryAction = self.parser.disambiguation_action()
         
         if secondaryAction:
             logging.error(u"POSTING: {0}".format(secondaryAction))
             self._catalog_post(secondaryAction)
         
-        # unsure if this still works
+        # unsure if this still works 
         if self.recovery_state < 0:
             self.recovery_stack[2] = course_unique
-
 
     def return_from_course(self):
         """Navigates back from course to subject"""
         logging.debug("Returning from a course")
-        #hacky, attempt to return from the new page first 
+        #hacky, attempt to return from the disambiguation page first 
         self._catalog_post('DERIVED_SAA_CRS_RETURN_PB')
         self._catalog_post('DERIVED_SSS_SEL_RETURN_PB')
 

--- a/navigation.py
+++ b/navigation.py
@@ -165,23 +165,44 @@ class SolusSession(object):
 
     # ----------------------------- Courses ------------------------------------- #
 
-    def open_course(self, course_unique):
+    def open_course(self, course_unique, action=None):
         """Opens a course page"""
-        logging.debug(u"Opening course with unique '{0}'".format(course_unique))
-
-        action = self.parser.course_action(course_unique)
-        if not action:
-            raise Exception(u"Tried to open a course with an invalid unique '{0}'".format(course_unique))
+        logging.debug(u"Opening course with unique '{0}', action: {1}".format(course_unique,action))
+        
+        actions = None
+        
+        if action == None:
+            actions = self.parser.course_action(course_unique)
+            if len(actions)==0:
+                raise Exception(u"Tried to open a course with an invalid unique '{0}'".format(course_unique))
+            action = actions[0] 
 
         self._catalog_post(action)
 
+        # this is no longer guaranteed to work
         if self.recovery_state < 0:
             self.recovery_stack[2] = course_unique
+
+        if actions != None and len(actions)>1:
+            return actions[1:]
+        else:
+            return [actions]
+
+    # def return_to_offerings(self):
+    #     """Navigates back from course to subject"""
+    #     logging.debug("Returning from a course to disambiguation page")
+    #     self._catalog_post('DERIVED_SAA_CRS_RETURN_PB')
+
+    #     self.recovery_stack[3] = None
+    #     self.recovery_stack[2] = None
+
 
     def return_from_course(self):
         """Navigates back from course to subject"""
         logging.debug("Returning from a course")
+        #hacky, try to return from the new page first 
         self._catalog_post('DERIVED_SAA_CRS_RETURN_PB')
+        self._catalog_post('DERIVED_SSS_SEL_RETURN_PB')
 
         self.recovery_stack[3] = None
         self.recovery_stack[2] = None

--- a/parser.py
+++ b/parser.py
@@ -9,7 +9,7 @@ class SolusParser(object):
     """Parses SOLUS's crappy HTML"""
 
     # For getting the correct tags
-    ALL_SUBJECTS = re.compile("DERIVED_SSS_BCC_GROUP_BOX_1\$84\$\$[0-9]+")
+    ALL_SUBJECTS = re.compile("DERIVED_SSS_BCC_GROUP_BOX_1\$147\$\$[0-9]+")
     ALL_COURSES = re.compile("CRSE_NBR\$[0-9]+")
     ALL_SECTIONS = re.compile("CLASS_SECTION\$[0-9]+")
     ALL_SECTION_TABLES = re.compile("CLASS\$scroll\$[0-9]+")
@@ -428,6 +428,8 @@ class SolusParser(object):
                             # Last datafield, has multiple type -> value mappings
                             comp_map = {}
                             for i in range(x, len(data), 2):
+                                if labels[i].string != COURSE_COMPS:
+                                    break
                                 comp_map[data[i].string] = data[i+1].get_text()
 
                             ret['extra'][KEYMAP[labels[x].string]] = comp_map

--- a/parser.py
+++ b/parser.py
@@ -120,12 +120,13 @@ class SolusParser(object):
         return tag["id"]
 
     def disambiguation_action(self):
+        """return the action for the last course on the disambiguation course. using the last course is not great but in the cases I found, it's always the most standard one"""
         tags = self.soup.find_all("a", id=self.ALL_CAREERS)
 
         if not tags:
             return None
 
-        return tags[len(tags)-1]["id"]
+        return tags[-1]["id"]
 
     def term_value(self, term_unique):
         """Return the value for the term unique"""
@@ -437,20 +438,21 @@ class SolusParser(object):
                     
                     data = table.find_all("span", {"class": EDITBOX_DATA_CLASS})
 
-                    dx = 0
+                    dataIndex = 0
                     for x in range(0, len(labels)):
                         if labels[x].string == COURSE_COMPS:
                             # Last datafield, has multiple type -> value mappings
                             comp_map = {}
                             for i in range(x, x+(len(data)-len(labels)), 2):
                                 comp_map[data[i].string] = data[i+1].get_text()
-                                dx = i+2
+                                #data index is lock-step with x until the course components, then it starts after the last component. (and is ahead of x)
+                                dataIndex = i+2
 
                             ret['extra'][KEYMAP[labels[x].string]] = comp_map
                             continue
                         elif labels[x].string in KEYMAP:
-                            ret['extra'][KEYMAP[labels[x].string]] = data[dx].get_text()
-                            dx+=1
+                            ret['extra'][KEYMAP[labels[x].string]] = data[dataIndex].get_text()
+                            dataIndex+=1
 
             # Process the CEAB information
             elif box_title == CEAB:

--- a/parser.py
+++ b/parser.py
@@ -11,6 +11,9 @@ class SolusParser(object):
     # For getting the correct tags
     ALL_SUBJECTS = re.compile("DERIVED_SSS_BCC_GROUP_BOX_1\$147\$\$[0-9]+")
     ALL_COURSES = re.compile("CRSE_NBR\$[0-9]+")
+    
+    ALL_CAREERS = re.compile("CAREER\$[0-9]+")
+
     ALL_SECTIONS = re.compile("CLASS_SECTION\$[0-9]+")
     ALL_SECTION_TABLES = re.compile("CLASS\$scroll\$[0-9]+")
 
@@ -108,12 +111,18 @@ class SolusParser(object):
 
     def course_action(self, course_unique):
         """Return the action for the course unique"""
-        tag = self.soup.find("a", id=self.ALL_COURSES, text=course_unique)
-        if not tag:
+        tags = [self.soup.find("a", id=self.ALL_COURSES, text=course_unique)]
+        logging.debug(tags)
+        if not tags[0]:
+            #case for new career disambiguation page
+            tags = self.soup.find_all("a", id=self.ALL_CAREERS)
+            logging.debug(tags)
+        if not tags:
             logging.warning(u"Couldn't find the course '{0}'".format(course_unique))
-            return None
+            return []
 
-        return tag["id"]
+        return [x["id"] for x in tags]
+
 
     def term_value(self, term_unique):
         """Return the value for the term unique"""

--- a/parser.py
+++ b/parser.py
@@ -111,16 +111,21 @@ class SolusParser(object):
 
     def course_action(self, course_unique):
         """Return the action for the course unique"""
-        tags = [self.soup.find("a", id=self.ALL_COURSES, text=course_unique)]
-        if not tags[0]:
-            #case for new career disambiguation page
-            tags = self.soup.find_all("a", id=self.ALL_CAREERS)
-        if not tags:
+        tag = self.soup.find("a", id=self.ALL_COURSES, text=course_unique)
+
+        if not tag:
             logging.warning(u"Couldn't find the course '{0}'".format(course_unique))
-            return []
+            return None
 
-        return [x["id"] for x in tags]
+        return tag["id"]
 
+    def disambiguation_action(self):
+        tags = self.soup.find_all("a", id=self.ALL_CAREERS)
+
+        if not tags:
+            return None
+
+        return tags[len(tags)-1]["id"]
 
     def term_value(self, term_unique):
         """Return the value for the term unique"""

--- a/parser.py
+++ b/parser.py
@@ -112,11 +112,9 @@ class SolusParser(object):
     def course_action(self, course_unique):
         """Return the action for the course unique"""
         tags = [self.soup.find("a", id=self.ALL_COURSES, text=course_unique)]
-        logging.debug(tags)
         if not tags[0]:
             #case for new career disambiguation page
             tags = self.soup.find_all("a", id=self.ALL_CAREERS)
-            logging.debug(tags)
         if not tags:
             logging.warning(u"Couldn't find the course '{0}'".format(course_unique))
             return []
@@ -431,20 +429,23 @@ class SolusParser(object):
                 if box_title == COURSE_DETAIL:
                     # Units and course components
                     labels = table.find_all("span", {"class": EDITBOX_LABEL_CLASS})
+                    
                     data = table.find_all("span", {"class": EDITBOX_DATA_CLASS})
+
+                    dx = 0
                     for x in range(0, len(labels)):
                         if labels[x].string == COURSE_COMPS:
                             # Last datafield, has multiple type -> value mappings
                             comp_map = {}
-                            for i in range(x, len(data), 2):
-                                if labels[i].string != COURSE_COMPS:
-                                    break
+                            for i in range(x, x+(len(data)-len(labels)), 2):
                                 comp_map[data[i].string] = data[i+1].get_text()
+                                dx = i+2
 
                             ret['extra'][KEYMAP[labels[x].string]] = comp_map
-                            break
+                            continue
                         elif labels[x].string in KEYMAP:
-                            ret['extra'][KEYMAP[labels[x].string]] = data[x].get_text()
+                            ret['extra'][KEYMAP[labels[x].string]] = data[dx].get_text()
+                            dx+=1
 
             # Process the CEAB information
             elif box_title == CEAB:

--- a/scraper.py
+++ b/scraper.py
@@ -18,6 +18,7 @@ class SolusScraper(object):
         try:
             self.scrape_letters()
         except Exception as e:
+            logging.debug(e)
             self.session.parser.dump_html()
             raise
 

--- a/scraper.py
+++ b/scraper.py
@@ -68,31 +68,25 @@ class SolusScraper(object):
 
         # Iterate over all courses
         for course_unique in all_courses:
-            remaining = self.session.open_course(course_unique)
+            self.session.open_course(course_unique)
             
-            while len(remaining) >= 1: 
-                
-                course_attrs = self.session.parser.course_attrs()
-                course_attrs['basic']['subject'] = subject['abbreviation']
+            # while len(remaining) >= 1: 
+            course_attrs = self.session.parser.course_attrs()
+            course_attrs['basic']['subject'] = subject['abbreviation']
 
-                logging.info(u"----Course: {number} - {title}".format(**course_attrs['basic']))
+            logging.info(u"----Course: {number} - {title}".format(**course_attrs['basic']))
 
-                writer.write_course(course_attrs)
-                try:
-                    self.session.show_sections()
-                except Exception as e:
-                    logging.error("Crashed when selecting a section")
-                    logging.error(e)
-                    raise
+            writer.write_course(course_attrs)
+            try:
+                self.session.show_sections()
+            except Exception as e:
+                logging.error("Crashed when selecting a section")
+                logging.error(e)
+                raise
 
-                self.scrape_terms(course_attrs)
-                self.session.return_from_course()
-                
-                if len(remaining)>1:
-                    self.session.open_course(course_unique, remaining[0])
-                
-                remaining = remaining[1:] 
-
+            self.scrape_terms(course_attrs)
+            self.session.return_from_course()
+            
 
     def scrape_terms(self, course):
         """Scrape terms"""

--- a/scraper.py
+++ b/scraper.py
@@ -70,21 +70,18 @@ class SolusScraper(object):
         for course_unique in all_courses:
             remaining = self.session.open_course(course_unique)
             
-            # logging.debug("remaining:&&&&&")
-            # logging.debug(remaining)
-                
             while len(remaining) >= 1: 
                 
                 course_attrs = self.session.parser.course_attrs()
                 course_attrs['basic']['subject'] = subject['abbreviation']
 
                 logging.info(u"----Course: {number} - {title}".format(**course_attrs['basic']))
-                logging.debug(u"COURSE DATA DUMP: {0}".format(course_attrs['extra']))
+
                 writer.write_course(course_attrs)
                 try:
                     self.session.show_sections()
                 except Exception as e:
-                    logging.error("##############################################we crashed when selecting a section")
+                    logging.error("Crashed when selecting a section")
                     logging.error(e)
                     raise
 

--- a/scraper.py
+++ b/scraper.py
@@ -70,7 +70,6 @@ class SolusScraper(object):
         for course_unique in all_courses:
             self.session.open_course(course_unique)
             
-            # while len(remaining) >= 1: 
             course_attrs = self.session.parser.course_attrs()
             course_attrs['basic']['subject'] = subject['abbreviation']
 


### PR DESCRIPTION
-One of the link ID regexes changed
-The format of course components changed, it is not always the last element of the list
-SOLUS has a new disambiguation page between courses and the course itself for cases that 1 course is offered in multiple "careers" aka distance vs Bader vs main campus. My solution attempts to select the main campus option and ignore the others to avoid front-end changes for now. 

Let me know if there are any stylistic or code review objections and I'll happily fix up the PR :)
Completed a full shallow scrape in 3 hrs with this.